### PR TITLE
Update instructions as per latest vivaldi version

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,11 +1,14 @@
 ### [Vivaldi](https://vivaldi.com)
 
-#### Using theme
+#### Configuring the theme
 
-1.  Go to Vivaldi Menu > Preferences > Themes
-2.  At the bottom of the window, look for a plus sign
-3.  Enter following colors
-4.  Background: `#282a36`
-5.  Foreground: `#f8f8f2`
-6.  Highlight: `#6272a4`
-7.  Accent: `#44475a`
+1. Go to Vivaldi Menu > Tools > Settings (or press Ctrl+F12)
+2. Select `Themes` in the sidebar
+3. Click the `+` sign, enter a name (ex: `Dracula`)
+4. Enter the following colors
+5. Background: `#282a36`
+6. Foreground: `#f8f8f2`
+7. Highlight: `#6272a4`
+8. Accent: `#44475a`
+
+Note: If you do not want Vivaldi to show per-site tab colors (ie: you only want to see the Dracula theme colors), uncheck the box beside `Accent Color from Active Page`.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,13 +2,16 @@
 
 #### Configuring the theme
 
-1. Go to Vivaldi Menu > Tools > Settings (or press Ctrl+F12)
+1. Open Vivaldi's Settings panel
+   - **On Windows**: Vivaldi menu > Tools > Settings (or press `Ctrl+F12`)
+   - **On Linux**: Tools menu > Settings (or press `Ctrl-F12`)
+   - **On macOS**: Vivaldi menu > Preferences > Themes (or press `⌘-,`)
 2. Select `Themes` in the sidebar
 3. Click the `+` sign, enter a name (ex: `Dracula`)
 4. Enter the following colors
-5. Background: `#282a36`
-6. Foreground: `#f8f8f2`
-7. Highlight: `#6272a4`
-8. Accent: `#44475a`
+   - Background: `#282a36`
+   - Foreground: `#f8f8f2`
+   - Highlight: `#6272a4`
+   - Accent: `#44475a`
 
 Note: If you do not want Vivaldi to show per-site tab colors (ie: you only want to see the Dracula theme colors), uncheck the box beside `Accent Color from Active Page`.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@
 1. Open Vivaldi's Settings panel
    - **On Windows**: Vivaldi menu > Tools > Settings (or press `Ctrl+F12`)
    - **On Linux**: Tools menu > Settings (or press `Ctrl-F12`)
-   - **On macOS**: Vivaldi menu > Preferences > Themes (or press `⌘-,`)
+   - **On macOS**: Vivaldi menu > Preferences (or press `⌘-,`)
 2. Select `Themes` in the sidebar
 3. Click the `+` sign, enter a name (ex: `Dracula`)
 4. Enter the following colors


### PR DESCRIPTION
A few changes so that the instructions match the latest vivaldi version settings UI. For instance, the menu as instructed at the first step is completely gone.

This also reword a few things and adds a note for people who want the UI colors to be consistent with Dracula colors instead of letting Vivaldi colorize the tabs depending on the websites colors